### PR TITLE
feat: add structured logging and metrics

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,150 +1,99 @@
 /**
- * Logger utility for the Pyodide Express Server
- *
- * Provides consistent logging across the application with different log levels
- * and optional file output for production environments. Detailed logs help
- * diagnose issues when executing Python code through Pyodide.
+ * Structured JSON logger with basic rotation and request ID support.
  */
-
 const fs = require('fs');
 const path = require('path');
+const { getRequestId } = require('./requestContext');
 
-class Logger {
-  constructor() {
-    this.levels = {
-      ERROR: 0,
-      WARN: 1,
-      INFO: 2,
-      DEBUG: 3
-    };
-    
-    this.currentLevel = this.levels[process.env.LOG_LEVEL?.toUpperCase()] || this.levels.INFO;
-    this.logFile = process.env.LOG_FILE || null;
-    
-    // Ensure log directory exists if log file is specified
-    if (this.logFile) {
-      const logDir = path.dirname(this.logFile);
-      if (!fs.existsSync(logDir)) {
-        fs.mkdirSync(logDir, { recursive: true });
-      }
-    }
-  }
+const levels = { error: 0, warn: 1, info: 2, debug: 3 };
+const currentLevel = levels[(process.env.LOG_LEVEL || 'info').toLowerCase()] ?? levels.info;
 
-  /**
-   * Format log message with timestamp and level
-   * @private
-   */
-  _formatMessage(level, message, ...args) {
-    const timestamp = new Date().toISOString();
-    const formattedArgs = args.length > 0 ? ' ' + args.map(arg => 
-      typeof arg === 'object' ? JSON.stringify(arg) : String(arg)
-    ).join(' ') : '';
-    
-    return `[${timestamp}] ${level}: ${message}${formattedArgs}`;
-  }
+const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logFile = process.env.LOG_FILE || path.join(logDir, 'server.log');
+const maxSize = parseInt(process.env.LOG_MAX_SIZE || 5 * 1024 * 1024, 10); // 5MB default
 
-  /**
-   * Write log message to console and optionally to file
-   * @private
-   */
-  _writeLog(level, levelNum, message, ...args) {
-    if (levelNum > this.currentLevel) return;
-
-    const formattedMessage = this._formatMessage(level, message, ...args);
-    
-    // Console output with colors
-    switch (level) {
-      case 'ERROR':
-        console.error('\x1b[31m%s\x1b[0m', formattedMessage); // Red
-        break;
-      case 'WARN':
-        console.warn('\x1b[33m%s\x1b[0m', formattedMessage); // Yellow
-        break;
-      case 'INFO':
-        console.info('\x1b[36m%s\x1b[0m', formattedMessage); // Cyan
-        break;
-      case 'DEBUG':
-        console.debug('\x1b[35m%s\x1b[0m', formattedMessage); // Magenta
-        break;
-      default:
-        console.log(formattedMessage);
-    }
-    
-    // File output (without colors)
-    if (this.logFile) {
-      try {
-        fs.appendFileSync(this.logFile, formattedMessage + '\n');
-      } catch (error) {
-        console.error('Failed to write to log file:', error.message);
-      }
-    }
-  }
-
-  /**
-   * Log error messages
-   */
-  error(message, ...args) {
-    this._writeLog('ERROR', this.levels.ERROR, message, ...args);
-  }
-
-  /**
-   * Log warning messages
-   */
-  warn(message, ...args) {
-    this._writeLog('WARN', this.levels.WARN, message, ...args);
-  }
-
-  /**
-   * Log info messages
-   */
-  info(message, ...args) {
-    this._writeLog('INFO', this.levels.INFO, message, ...args);
-  }
-
-  /**
-   * Log debug messages
-   */
-  debug(message, ...args) {
-    this._writeLog('DEBUG', this.levels.DEBUG, message, ...args);
-  }
-
-  /**
-   * Set log level
-   */
-  setLevel(level) {
-    const upperLevel = level.toUpperCase();
-    if (this.levels[upperLevel] !== undefined) {
-      this.currentLevel = this.levels[upperLevel];
-      this.info(`Log level set to ${upperLevel}`);
-    } else {
-      this.warn(`Invalid log level: ${level}. Valid levels: ${Object.keys(this.levels).join(', ')}`);
-    }
-  }
-
-  /**
-   * Get current log level
-   */
-  getLevel() {
-    return Object.keys(this.levels).find(key => this.levels[key] === this.currentLevel);
-  }
-  /**
-   * Get log file path
-   */
-  getLogFile() {
-    return this.logFile;
-  }
-
-  /**
-   * Get log info for status checks
-   */
-  getLogInfo() {
-    return {
-      level: this.getLevel(),
-      logFile: this.logFile,
-      isFileLoggingEnabled: !!this.logFile,
-      logDirectory: this.logFile ? require('path').dirname(this.logFile) : null
-    };
+if (logFile) {
+  const dir = path.dirname(logFile);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
   }
 }
 
-module.exports = new Logger();
+function rotateIfNeeded() {
+  if (!logFile || !fs.existsSync(logFile)) return;
+  const { size } = fs.statSync(logFile);
+  if (size < maxSize) return;
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const rotated = `${logFile}.${timestamp}`;
+  fs.renameSync(logFile, rotated);
+}
+
+function write(level, levelNum, message, meta = {}) {
+  if (levelNum > currentLevel) return;
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...meta,
+  };
+  const requestId = getRequestId();
+  if (requestId) entry.requestId = requestId;
+  const line = JSON.stringify(entry);
+
+  switch (level) {
+    case 'error':
+      console.error(line);
+      break;
+    case 'warn':
+      console.warn(line);
+      break;
+    case 'info':
+      console.log(line);
+      break;
+    case 'debug':
+      console.debug(line);
+      break;
+    default:
+      console.log(line);
+  }
+
+  if (logFile) {
+    try {
+      rotateIfNeeded();
+      fs.appendFileSync(logFile, line + '\n');
+    } catch (err) {
+      console.error('Failed to write to log file:', err.message);
+    }
+  }
+}
+
+const logger = {
+  error(message, meta) {
+    write('error', levels.error, message, meta);
+  },
+  warn(message, meta) {
+    write('warn', levels.warn, message, meta);
+  },
+  info(message, meta) {
+    write('info', levels.info, message, meta);
+  },
+  debug(message, meta) {
+    write('debug', levels.debug, message, meta);
+  },
+  getLogInfo() {
+    return {
+      level: Object.keys(levels).find((k) => levels[k] === currentLevel),
+      logFile,
+      isFileLoggingEnabled: !!logFile,
+      logDirectory: logFile ? path.dirname(logFile) : null,
+    };
+  },
+  getLogFile() {
+    return logFile;
+  },
+  getLevel() {
+    return Object.keys(levels).find((k) => levels[k] === currentLevel);
+  },
+};
+
+module.exports = logger;

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -1,0 +1,39 @@
+const metrics = {
+  requestsTotal: 0,
+  requestErrorsTotal: 0,
+  requestDurationSecondsSum: 0,
+  requestDurationSecondsCount: 0,
+};
+
+function metricsMiddleware(req, res, next) {
+  metrics.requestsTotal += 1;
+  const start = process.hrtime.bigint();
+  res.on('finish', () => {
+    const end = process.hrtime.bigint();
+    const duration = Number(end - start) / 1e9; // seconds
+    metrics.requestDurationSecondsSum += duration;
+    metrics.requestDurationSecondsCount += 1;
+    if (res.statusCode >= 500) {
+      metrics.requestErrorsTotal += 1;
+    }
+  });
+  next();
+}
+
+function metricsEndpoint(req, res) {
+  res.setHeader('Content-Type', 'text/plain; version=0.0.4');
+  let output = '';
+  output += '# HELP http_requests_total Total number of HTTP requests\n';
+  output += '# TYPE http_requests_total counter\n';
+  output += `http_requests_total ${metrics.requestsTotal}\n`;
+  output += '# HELP http_request_errors_total Total number of HTTP error responses (5xx)\n';
+  output += '# TYPE http_request_errors_total counter\n';
+  output += `http_request_errors_total ${metrics.requestErrorsTotal}\n`;
+  output += '# HELP http_request_duration_seconds Summary of HTTP request durations in seconds\n';
+  output += '# TYPE http_request_duration_seconds summary\n';
+  output += `http_request_duration_seconds_sum ${metrics.requestDurationSecondsSum}\n`;
+  output += `http_request_duration_seconds_count ${metrics.requestDurationSecondsCount}\n`;
+  res.send(output);
+}
+
+module.exports = { metricsMiddleware, metricsEndpoint };

--- a/src/utils/requestContext.js
+++ b/src/utils/requestContext.js
@@ -1,0 +1,19 @@
+const { AsyncLocalStorage } = require('async_hooks');
+const { randomUUID } = require('crypto');
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+function requestContextMiddleware(req, res, next) {
+  const requestId = randomUUID();
+  asyncLocalStorage.run({ requestId }, () => {
+    res.setHeader('X-Request-Id', requestId);
+    next();
+  });
+}
+
+function getRequestId() {
+  const store = asyncLocalStorage.getStore();
+  return store ? store.requestId : undefined;
+}
+
+module.exports = { requestContextMiddleware, getRequestId };


### PR DESCRIPTION
## Summary
- add request-scoped context to capture and propagate request IDs
- introduce structured JSON logger with simple rotation
- track basic request metrics and expose `/metrics` endpoint

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'test-client.js')*


------
https://chatgpt.com/codex/tasks/task_e_6892cc8353548329ac9fe32c7b44f3a2