### PR TITLE
Add curl examples and Python endpoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,17 @@ See [docs/architecture.md](docs/architecture.md) and [`pyodide_arch.md`](pyodide
 
 ## Tests
 Some tests expect the server to be running locally on port 3000.
+
 ```bash
 npm test
+```
+
+A Python test suite using the `requests` library also exercises the API. Install
+the dependency and run it with `unittest`:
+
+```bash
+pip install requests
+python -m unittest tests.test_api
 ```
 
 ## Contributing

--- a/docs/curl-commands.md
+++ b/docs/curl-commands.md
@@ -1,0 +1,204 @@
+# Curl commands for Pyodide Express Server
+
+These examples show how to test the available endpoints with `curl`.
+For each endpoint there is a version that works on Unix-like shells
+(macOS/Linux) and a Windows PowerShell variant. Replace `sample.csv`
+with the path to your own file when needed.
+
+> The server is assumed to be running on `http://localhost:3000`.
+
+## 1. Server health
+
+**Unix**
+```sh
+curl http://localhost:3000/health
+```
+
+**Windows**
+```powershell
+curl http://localhost:3000/health
+```
+
+## 2. Pyodide status
+
+**Unix**
+```sh
+curl http://localhost:3000/api/status
+```
+
+**Windows**
+```powershell
+curl http://localhost:3000/api/status
+```
+
+## 3. Execute Python code (`/execute`)
+
+**Unix**
+```sh
+curl -X POST http://localhost:3000/api/execute \
+  -H "Content-Type: application/json" \
+  -d '{"code": "\"\"\"curl demo\"\"\"\nname=\"Unix\"\nf\"Hello {name}\""}'
+```
+
+**Windows**
+```powershell
+curl -X POST "http://localhost:3000/api/execute" \
+  -H "Content-Type: application/json" \
+  -d "{\"code\": \"\\\"\\\"\\\"curl demo\\\"\\\"\\\"\\nname=\\\"Windows\\\"\\nf\\\"Hello {name}\\\"\"}"
+```
+
+## 4. Execute raw Python code (`/execute-raw`)
+
+**Unix**
+```sh
+curl -X POST http://localhost:3000/api/execute-raw \
+  -H "Content-Type: text/plain" \
+  --data '"""raw demo"""\nname="Unix"\nprint(f"""Hi {name}""")'
+```
+
+**Windows**
+```powershell
+curl -X POST "http://localhost:3000/api/execute-raw" \
+  -H "Content-Type: text/plain" \
+  --data "\"\"\"raw demo\"\"\"\\nname=\\\"Windows\\\"\\nprint(f\"\"\"Hi {name}\"\"\")"
+```
+
+## 5. Upload CSV (`/upload-csv`)
+
+**Unix**
+```sh
+curl -X POST http://localhost:3000/api/upload-csv \
+  -F "csvFile=@sample.csv"
+```
+
+**Windows**
+```powershell
+curl -X POST "http://localhost:3000/api/upload-csv" \
+  -F "csvFile=@sample.csv"
+```
+
+## 6. List uploaded files
+
+**Unix**
+```sh
+curl http://localhost:3000/api/uploaded-files
+```
+
+**Windows**
+```powershell
+curl http://localhost:3000/api/uploaded-files
+```
+
+## 7. File information
+
+Replace `FILENAME` with the name returned by the upload endpoint.
+
+**Unix**
+```sh
+curl http://localhost:3000/api/file-info/FILENAME
+```
+
+**Windows**
+```powershell
+curl "http://localhost:3000/api/file-info/FILENAME"
+```
+
+## 8. List files in Pyodide filesystem
+
+**Unix**
+```sh
+curl http://localhost:3000/api/pyodide-files
+```
+
+**Windows**
+```powershell
+curl http://localhost:3000/api/pyodide-files
+```
+
+## 9. Delete file from Pyodide filesystem
+
+**Unix**
+```sh
+curl -X DELETE http://localhost:3000/api/pyodide-files/FILENAME
+```
+
+**Windows**
+```powershell
+curl -X DELETE "http://localhost:3000/api/pyodide-files/FILENAME"
+```
+
+## 10. Delete uploaded file
+
+**Unix**
+```sh
+curl -X DELETE http://localhost:3000/api/uploaded-files/FILENAME
+```
+
+**Windows**
+```powershell
+curl -X DELETE "http://localhost:3000/api/uploaded-files/FILENAME"
+```
+
+## 11. Install a Python package
+
+**Unix**
+```sh
+curl -X POST http://localhost:3000/api/install-package \
+  -H "Content-Type: application/json" \
+  -d '{"package": "beautifulsoup4"}'
+```
+
+**Windows**
+```powershell
+curl -X POST "http://localhost:3000/api/install-package" \
+  -H "Content-Type: application/json" \
+  -d "{\"package\": \"beautifulsoup4\"}"
+```
+
+## 12. List installed packages
+
+**Unix**
+```sh
+curl http://localhost:3000/api/packages
+```
+
+**Windows**
+```powershell
+curl http://localhost:3000/api/packages
+```
+
+## 13. Reset Pyodide environment
+
+**Unix**
+```sh
+curl -X POST http://localhost:3000/api/reset
+```
+
+**Windows**
+```powershell
+curl -X POST "http://localhost:3000/api/reset"
+```
+
+## 14. Server statistics
+
+**Unix**
+```sh
+curl http://localhost:3000/api/stats
+```
+
+**Windows**
+```powershell
+curl http://localhost:3000/api/stats
+```
+
+These commands provide a quick way to verify every API route.
+
+## Running the Python API tests
+
+The repository includes `tests/test_api.py`, which programmatically exercises
+all endpoints using the `requests` library. Install the dependency and run:
+
+```bash
+pip install requests
+python -m unittest tests.test_api
+```

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,170 @@
+import os
+import tempfile
+import time
+import subprocess
+import requests
+import unittest
+
+BASE_URL = "http://localhost:3000"
+
+
+def wait_for_server(url: str, timeout: int = 120):
+    """Poll ``url`` until it responds or timeout expires."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            r = requests.get(url, timeout=5)
+            if r.status_code == 200:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"Server at {url} did not start in time")
+
+
+class APITestCase(unittest.TestCase):
+    """Exercise API endpoints and report results per test."""
+
+    server_filename: str | None = None
+    pyodide_name: str | None = None
+
+    @classmethod
+    def setUpClass(cls):
+        # Start the server in a subprocess
+        cls.server = subprocess.Popen(["node", "src/server.js"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        wait_for_server(f"{BASE_URL}/health")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.terminate()
+        try:
+            cls.server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            cls.server.kill()
+
+    def test_01_health(self):
+        r = requests.get(f"{BASE_URL}/health")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json().get("status"), "ok")
+
+    def test_02_status(self):
+        r = requests.get(f"{BASE_URL}/api/status")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("isReady", r.json())
+
+    def test_03_pyodide_health(self):
+        r = requests.get(f"{BASE_URL}/api/health")
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json().get("success"))
+
+    def test_04_stats(self):
+        r = requests.get(f"{BASE_URL}/api/stats")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("uptime", r.json())
+
+    def test_05_install_package(self):
+        r = requests.post(
+            f"{BASE_URL}/api/install-package",
+            json={"package": "beautifulsoup4"},
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("success", r.json())
+
+    def test_06_list_packages(self):
+        r = requests.get(f"{BASE_URL}/api/packages")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("result", r.json())
+
+    def test_07_execute(self):
+        exec_code = '''"""
+basic demonstration
+"""
+name = "World"
+f"Hello {name}"
+'''
+        r = requests.post(f"{BASE_URL}/api/execute", json={"code": exec_code})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json().get("result"), "Hello World")
+
+    def test_08_execute_raw(self):
+        raw_code = '''"""
+raw execution sample
+"""
+x = 3
+f"{x + 3}"
+'''
+        r = requests.post(
+            f"{BASE_URL}/api/execute-raw",
+            data=raw_code,
+            headers={"Content-Type": "text/plain"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json().get("result"), "6")
+
+    def test_09_upload_csv(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as tmp:
+            tmp.write("value\n1\n2\n3\n")
+            tmp_path = tmp.name
+        with open(tmp_path, "rb") as fh:
+            r = requests.post(
+                f"{BASE_URL}/api/upload-csv",
+                files={"csvFile": ("data.csv", fh, "text/csv")},
+            )
+        os.unlink(tmp_path)
+        self.assertEqual(r.status_code, 200)
+        upload_data = r.json()
+        self.assertTrue(upload_data.get("success"))
+        self.__class__.pyodide_name = upload_data["file"]["pyodideFilename"]
+        self.__class__.server_filename = os.path.basename(upload_data["file"]["tempPath"])
+
+    def test_10_list_uploaded_files(self):
+        r = requests.get(f"{BASE_URL}/api/uploaded-files")
+        self.assertEqual(r.status_code, 200)
+        uploaded_names = [f["filename"] for f in r.json().get("files", [])]
+        self.assertIn(self.__class__.server_filename, uploaded_names)
+
+    def test_11_file_info(self):
+        r = requests.get(f"{BASE_URL}/api/file-info/{self.__class__.server_filename}")
+        self.assertEqual(r.status_code, 200)
+        info = r.json()
+        self.assertTrue(info["uploadedFile"]["exists"])
+        self.assertTrue(info["pyodideFile"]["exists"])
+
+    def test_12_execute_with_uploaded_file(self):
+        code = f'''"""
+read csv and compute sum using pandas
+"""
+import pandas as pd
+df = pd.read_csv("{self.__class__.pyodide_name}")
+total = df["value"].sum()
+f"sum={total}"
+'''
+        r = requests.post(f"{BASE_URL}/api/execute", json={"code": code})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json().get("result"), "sum=6")
+
+    def test_13_list_pyodide_files(self):
+        r = requests.get(f"{BASE_URL}/api/pyodide-files")
+        self.assertEqual(r.status_code, 200)
+        py_files = [f["name"] for f in r.json().get("result", {}).get("files", [])]
+        self.assertIn(self.__class__.pyodide_name, py_files)
+
+    def test_14_delete_pyodide_file(self):
+        r = requests.delete(f"{BASE_URL}/api/pyodide-files/{self.__class__.pyodide_name}")
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json().get("success"))
+
+    def test_15_delete_uploaded_file(self):
+        r = requests.delete(f"{BASE_URL}/api/uploaded-files/{self.__class__.server_filename}")
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json().get("success"))
+
+    def test_16_reset(self):
+        r = requests.post(f"{BASE_URL}/api/reset")
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json().get("success"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `docs/curl-commands.md` covering curl invocations for every API endpoint, with Unix and Windows examples including f-string and triple-quoted snippets for code execution endpoints
- create `tests/test_api.py` using `requests` to exercise endpoints including uploading a CSV and executing code that reads it, with per-endpoint test methods for detailed results
- update endpoint tests to run Python snippets containing f-strings and triple-quoted comments
- document how to run the Python API tests in both `README.md` and `docs/curl-commands.md`

## Testing
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests (from versions: none))*
- `python -m unittest tests.test_api` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: Error: Cannot find module '/workspace/pyodide-express-server/test-client.js')*


------
https://chatgpt.com/codex/tasks/task_e_6892e10ad67083298ccf460aeff943b4